### PR TITLE
 PR: Ramener les changements de dev vers main

### DIFF
--- a/OperationsMathematiques.cs
+++ b/OperationsMathematiques.cs
@@ -10,6 +10,11 @@ namespace H23_Dev_Info_Examen2
         public static double CalculerMoyenne(List<int> valeurs)
         {
             double moyenne = valeurs.Average();
+            if(valeurs.Count == 0)
+            {
+                moyenne = -1;                              
+            }
+            Console.WriteLine($"la moyenne est : {moyenne}")  
             return moyenne;                                          
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -10,6 +10,9 @@ namespace H23_Dev_Info_Examen2
         {
             var liste = new List<int>();
             var moyenne = OperationsMathematiques.CalculerMoyenne(liste);
+            if(moyenne == -1){
+                Console.WriteLine("Données invalides")
+            }
             Console.WriteLine(moyenne);
         }
     }

--- a/exercice1.txt
+++ b/exercice1.txt
@@ -1,2 +1,51 @@
 insérez les commandes relatives à l'exercice 1 ci-dessous:
 
+git add .
+git commit -m "commit initial"
+
+
+git status
+git add Cheval.cs
+git commit -m "AJout de la classe cheval"
+
+git status
+git add Animal.cs
+git commit -m "AJout de la classe Animal"
+
+git status
+git add Voiture.cs
+git commit -m "AJout de la classe Voiture"
+
+git reset --hard HEAD~1
+git status
+
+git branch dev id_commit_precedent
+
+git branch
+git checkout dev
+git branch
+git status  (apres la maj classe Cheval)
+git add Cheval.cs
+git commit -m "dev-maj classe Cheval"
+
+git branch
+git status
+git add Animal.cs
+git commit -m "dev-maj de la classe Animal"
+
+git checkout main
+git branch
+git merge dev
+
+git branch -d dev
+
+
+
+
+
+
+
+
+
+
+

--- a/exercice2.txt
+++ b/exercice2.txt
@@ -4,6 +4,7 @@ Supprimer la branche « feature/footer » sachant que celle-ci n’a pas été p
 
 # commande(s):
 ```
+git branch -D feature/footer
 
 ```
 
@@ -12,16 +13,16 @@ Lister toutes les branches, qu’elles soient locales ou distantes.
 
 # commande(s):
 ```
+git branch -a
 
 ```
-
 
 # énoncé 3:
 Corriger le commentaire du dernier commit. Le remplacer par « configuration du sticky header ».
 
-
 # commande(s):
 ```
+git commit --amend --only –m "configuration du sticky header"
 
 ```
 
@@ -30,6 +31,7 @@ Pousser la branche « hotfix/stackoverflow » vers GitHub.
 
 # commande(s):
 ```
+git push -u origin hotfix/stackoverflow
 
 ```
 
@@ -38,5 +40,6 @@ Redéfinir l’adresse courriel pour le dépôt local par « obiwan.kenobi@lucas
 
 # commande(s):
 ```
+git config user.email "obiwan.kenobi@lucasfilms.net"
 
 ```


### PR DESCRIPTION
Les raisons de ce PR sont : 

1.  les modifications de la méthode « CalculerMoyenne » afin qu’elle retourne « -1 » si la liste passée en paramètre d’entrée est null ou vide.
2.   les modifications de la méthode « Main » afin qu’elle affiche le message « données invalides » si la moyenne retournée est égale à -1